### PR TITLE
arregle el error de bloquear figura

### DIFF
--- a/app/services/block_figure.py
+++ b/app/services/block_figure.py
@@ -34,12 +34,11 @@ async def block_figure_service(
             db.query(CardFig)
             .filter(
                 CardFig.game_id == figure.game_id,
-                CardFig.owner_id == player_id,
+                CardFig.owner_id == figure.owner_id,
                 CardFig.in_hand == True,
             )
             .all()
         )
-        print(len_card_figs_from_player)
         if len_card_figs_from_player < 2:
             raise ValueError(
                 "You can't block a figure from a player that has less than 2 figures in hand"


### PR DESCRIPTION
This pull request includes a small change to the `block_figure_service` function in the `app/services/block_figure.py` file. The change corrects the filtering condition by replacing `player_id` with `figure.owner_id` to ensure the correct owner is checked when querying `CardFig`.

* [`app/services/block_figure.py`](diffhunk://#diff-6e003ec5fbd563d6d0f98d421de8ec9720ac2d6bc6e48ab3b46360c8c569566aL37-L42): Corrected the filtering condition in the `block_figure_service` function to use `figure.owner_id` instead of `player_id`.